### PR TITLE
Surface detailed error messages to library users

### DIFF
--- a/BSPParser.cpp
+++ b/BSPParser.cpp
@@ -80,8 +80,14 @@ void BSPMap::ParseGameLumps()
 			case 6:
 				ParseStaticPropLump(mpGameLumps[i], &mpStaticPropsV6);
 				break;
+			// A non-standard version 7 static prop lump exists in the 2013 multiplayer SDK exclusively
+			// This may appear as either version 7 or 10, but is not compatible with other engine versions' v7 or v10 (thank you Valve)
+			case 7:
+			case 10:
+				ParseStaticPropLump(mpGameLumps[i], &mpStaticPropsV7Multiplayer2013);
+				break;
 			default:
-				throw ParseError("Unsupported static prop lump version", LUMP::GAME_LUMP);
+				throw ParseError((std::string("Unsupported static prop lump version ") + std::to_string(mpGameLumps[i].version)).c_str(), LUMP::GAME_LUMP);
 			}
 
 			break;
@@ -636,6 +642,8 @@ BSPStaticProp BSPMap::GetStaticProp(const int32_t index) const
 		return GetStaticPropInternal(index, mpStaticPropsV5);
 	case 6:
 		return GetStaticPropInternal(index, mpStaticPropsV6);
+	case 7:
+		return GetStaticPropInternal(index, mpStaticPropsV7Multiplayer2013);
 	default:
 		throw std::runtime_error("Unsupported static prop version");
 	}

--- a/BSPParser.h
+++ b/BSPParser.h
@@ -209,6 +209,9 @@ private:
 	bool Triangulate();
 
 public:
+	std::string errorReason = "Unknown error";
+	BSPEnums::LUMP errorLump = BSPEnums::LUMP::NONE;
+
 	// Parses and triangulates a BSP from raw data
 	// clockwise sets which winding the triangles should have (default true)
 	BSPMap(const uint8_t* pFileData, size_t dataSize, bool clockwise = true);

--- a/BSPParser.h
+++ b/BSPParser.h
@@ -113,7 +113,7 @@ private:
 		);
 	}
 
-	bool ParseGameLumps();
+	void ParseGameLumps();
 
 	template<class StaticProp>
 	void ParseStaticPropLump(const BSPStructs::GameLump& gameLump, const StaticProp** pPtrOut)
@@ -210,7 +210,7 @@ private:
 
 	bool GetSurfEdgeVerts(int32_t index, BSPStructs::Vector* pVertA, BSPStructs::Vector* pVertB = nullptr) const;
 
-	bool Triangulate();
+	void Triangulate();
 
 public:
 	std::string errorReason = "Unknown error";

--- a/BSPParser.h
+++ b/BSPParser.h
@@ -89,6 +89,7 @@ private:
 	const BSPStructs::StaticPropV4* mpStaticPropsV4;
 	const BSPStructs::StaticPropV5* mpStaticPropsV5;
 	const BSPStructs::StaticPropV6* mpStaticPropsV6;
+	const BSPStructs::StaticPropV7Multiplayer2013* mpStaticPropsV7Multiplayer2013;
 	int32_t mNumStaticProps = 0U;
 
 	// Triangulation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
 	"Displacements/SubEdgeIterator.cpp"
 
 	"Errors/ParseError.cpp"
+	"Errors/TriangulationError.cpp"
 )
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(
 	"Displacements/TBNGen.cpp"
 	"Displacements/NormalBlending.cpp"
 	"Displacements/SubEdgeIterator.cpp"
+
+	"Errors/ParseError.cpp"
 )
 
 target_include_directories(

--- a/Errors/ParseError.cpp
+++ b/Errors/ParseError.cpp
@@ -1,0 +1,3 @@
+#include "ParseError.hpp"
+
+BSPErrors::ParseError::ParseError(const char* const message, BSPEnums::LUMP lump) : std::exception(message), lump(lump) {}

--- a/Errors/ParseError.hpp
+++ b/Errors/ParseError.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <exception>
+#include <string>
+#include "FileFormat/Enums.h"
+
+namespace BSPErrors {
+	class ParseError : public std::exception {
+	public:
+		ParseError(const char* message, BSPEnums::LUMP lump);
+
+		BSPEnums::LUMP lump;
+	};
+}

--- a/Errors/TriangulationError.cpp
+++ b/Errors/TriangulationError.cpp
@@ -1,0 +1,3 @@
+#include "TriangulationError.hpp"
+
+BSPErrors::TriangulationError::TriangulationError(const char* const message) : std::exception(message) {}

--- a/Errors/TriangulationError.hpp
+++ b/Errors/TriangulationError.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <exception>
+#include "FileFormat/Enums.h"
+
+namespace BSPErrors {
+	class TriangulationError : public std::exception {
+	public:
+		TriangulationError(const char* message);
+	};
+}

--- a/FileFormat/Enums.h
+++ b/FileFormat/Enums.h
@@ -79,7 +79,8 @@ namespace BSPEnums {
 		OVERLAY_FADES,
 		OVERLAY_SYSTEM_LEVELS,
 		PHYSLEVEL,
-		DISP_MULTIBLEND
+		DISP_MULTIBLEND,
+		NONE = std::numeric_limits<uint32_t>::max(),
 	};
 
 	#define GAMELUMP_MAKE_CODE(a, b, c, d) ((a) << 24 | (b) << 16 | (c) << 8 | (d) << 0)

--- a/FileFormat/Enums.h
+++ b/FileFormat/Enums.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 namespace BSPEnums {
 	enum class LUMP : uint32_t

--- a/FileFormat/Parser.cpp
+++ b/FileFormat/Parser.cpp
@@ -21,8 +21,8 @@ void BSPParser::GetLumpPtr(
 	}
 
 	const Lump& lump = pHeader->lumps[static_cast<size_t>(lumpType)];
-	if (lump.offset <= 0) {
-		throw ParseError("Lump offset is less than 1", lumpType);
+	if (lump.offset < 0) {
+		throw ParseError("Lump offset is before the start of the data", lumpType);
 	}
 	if (lump.offset + lump.length > size) {
 		throw ParseError("Lump offset plus length overruns the data", lumpType);

--- a/FileFormat/Parser.cpp
+++ b/FileFormat/Parser.cpp
@@ -4,40 +4,53 @@
 #include <cmath>
 
 #include "Enums.h"
+#include "Errors/ParseError.hpp"
 
 using namespace BSPStructs;
 using namespace BSPEnums;
+using BSPErrors::ParseError;
 
-bool BSPParser::GetLumpPtr(
+void BSPParser::GetLumpPtr(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader, const LUMP lumpType,
 	const uint8_t** pPtrOut
 )
 {
-	if (pData == nullptr || pHeader == nullptr || pPtrOut == nullptr) return false;
+	if (pData == nullptr || pHeader == nullptr || pPtrOut == nullptr) {
+		throw ParseError("Data, header or output pointers are null", lumpType);
+	}
 
 	const Lump& lump = pHeader->lumps[static_cast<size_t>(lumpType)];
-	if (lump.offset <= 0) return false;
-	if (lump.offset + lump.length > size) return false;
+	if (lump.offset <= 0) {
+		throw ParseError("Lump offset is less than 1", lumpType);
+	}
+	if (lump.offset + lump.length > size) {
+		throw ParseError("Lump offset plus length overruns the data", lumpType);
+	}
 
 	*pPtrOut = pData + lump.offset;
-	return true;
 }
 
-bool BSPParser::ParseHeader(
+void BSPParser::ParseHeader(
 	const uint8_t* pData, const size_t size,
 	const Header** pHeaderPtr
 )
 {
-	if (pData == nullptr || pHeaderPtr == nullptr) return false;
-	if (size < sizeof(Header)) return false;
+	if (pData == nullptr || pHeaderPtr == nullptr) {
+		throw ParseError("Data or header pointers are null", LUMP::NONE);
+	}
+	if (size < sizeof(Header)) {
+		throw ParseError("Data size is smaller than the file header", LUMP::NONE);
+	}
 
 	*pHeaderPtr = reinterpret_cast<const Header*>(pData);
-	return (*pHeaderPtr)->ident == IDBSPHEADER;
+	if ((*pHeaderPtr)->ident != IDBSPHEADER) {
+		throw ParseError("Header's identifier is not 'VBSP'", LUMP::NONE);
+	}
 }
 
 template<class LumpDatatype>
-bool ParseLumpBase(
+void ParseLumpBase(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const LumpDatatype** pArray, size_t* pLength,
@@ -49,30 +62,33 @@ bool ParseLumpBase(
 		pHeader == nullptr ||
 		pArray == nullptr ||
 		pLength == nullptr
-	) return false;
+	) {
+		throw ParseError("Data, header, array or length pointers are null", lump);
+	}
 
-	if (pHeader->lumps[static_cast<size_t>(lump)].length % sizeof(LumpDatatype) != 0)
-		return false;
+	if (pHeader->lumps[static_cast<size_t>(lump)].length % sizeof(LumpDatatype) != 0) {
+		throw ParseError("Size of the lump is not an exact multiple of the size of its items", lump);
+	}
 
 	const uint8_t* pLumpData;
-	if (BSPParser::GetLumpPtr(pData, size, pHeader, lump, &pLumpData) == false)
-		return false;
+	BSPParser::GetLumpPtr(pData, size, pHeader, lump, &pLumpData);
 
 	*pLength = pHeader->lumps[static_cast<size_t>(lump)].length / sizeof(LumpDatatype);
-	if (*pLength > max) return false;
+	if (*pLength > max) {
+		throw ParseError("Number of lump items exceeds the Source engine maximum", lump);
+	}
 
 	*pArray = reinterpret_cast<const LumpDatatype*>(pLumpData);
-	return true;
 }
 
-bool BSPParser::ParseArray(
+void BSPParser::ParseArray(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const char** pArray, size_t* pLength,
 	const LUMP lump, const size_t max
 )
 {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -80,14 +96,14 @@ bool BSPParser::ParseArray(
 	);
 }
 
-bool BSPParser::ParseArray(
+void BSPParser::ParseArray(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const int32_t** pArray, size_t* pLength,
 	const LUMP lump, const size_t max
 )
 {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -95,14 +111,14 @@ bool BSPParser::ParseArray(
 	);
 }
 
-bool BSPParser::ParseArray(
+void BSPParser::ParseArray(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const Vector** pArray, size_t* pLength,
 	const LUMP lump, const size_t max
 )
 {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -110,12 +126,12 @@ bool BSPParser::ParseArray(
 	);
 }
 
-bool BSPParser::ParseLump(
+void BSPParser::ParseLump(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const Plane** pArray, size_t* pLength
 ) {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -123,12 +139,12 @@ bool BSPParser::ParseLump(
 	);
 }
 
-bool BSPParser::ParseLump(
+void BSPParser::ParseLump(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const Edge** pArray, size_t* pLength
 ) {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -136,12 +152,12 @@ bool BSPParser::ParseLump(
 	);
 }
 
-bool BSPParser::ParseLump(
+void BSPParser::ParseLump(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const Face** pArray, size_t* pLength
 ) {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -149,12 +165,12 @@ bool BSPParser::ParseLump(
 	);
 }
 
-bool BSPParser::ParseLump(
+void BSPParser::ParseLump(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const TexInfo** pArray, size_t* pLength
 ) {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -162,12 +178,12 @@ bool BSPParser::ParseLump(
 	);
 }
 
-bool BSPParser::ParseLump(
+void BSPParser::ParseLump(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const TexData** pArray, size_t* pLength
 ) {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -175,12 +191,12 @@ bool BSPParser::ParseLump(
 	);
 }
 
-bool BSPParser::ParseLump(
+void BSPParser::ParseLump(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const Model** pArray, size_t* pLength
 ) {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -188,12 +204,12 @@ bool BSPParser::ParseLump(
 	);
 }
 
-bool BSPParser::ParseLump(
+void BSPParser::ParseLump(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const DispInfo** pArray, size_t* pLength
 ) {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,
@@ -201,12 +217,12 @@ bool BSPParser::ParseLump(
 	);
 }
 
-bool BSPParser::ParseLump(
+void BSPParser::ParseLump(
 	const uint8_t* pData, const size_t size,
 	const Header* pHeader,
 	const DispVert** pArray, size_t* pLength
 ) {
-	return ParseLumpBase(
+	ParseLumpBase(
 		pData, size,
 		pHeader,
 		pArray, pLength,

--- a/FileFormat/Parser.h
+++ b/FileFormat/Parser.h
@@ -5,83 +5,83 @@
 
 namespace BSPParser
 {
-	bool GetLumpPtr(
-		const uint8_t* pData, const size_t size,
-		const BSPStructs::Header* pHeader, const  BSPEnums::LUMP lump,
+	void GetLumpPtr(
+		const uint8_t* pData, size_t size,
+		const BSPStructs::Header* pHeader, BSPEnums::LUMP lump,
 		const uint8_t** pPtrOut
 	);
 
-	bool ParseHeader(
-		const uint8_t* pData, const size_t size,
+	void ParseHeader(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header** pHeaderPtr
 	);
 
-	bool ParseArray(
-		const uint8_t* pData, const size_t size,
+	void ParseArray(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const char** pArray, size_t* pLength,
-		const  BSPEnums::LUMP lump, const size_t max
+		BSPEnums::LUMP lump, size_t max
 	);
 
-	bool ParseArray(
-		const uint8_t* pData, const size_t size,
+	void ParseArray(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const int32_t** pArray, size_t* pLength,
-		const  BSPEnums::LUMP lump, const size_t max
+		BSPEnums::LUMP lump, size_t max
 	);
 
-	bool ParseArray(
-		const uint8_t* pData, const size_t size,
+	void ParseArray(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::Vector** pArray, size_t* pLength,
-		const  BSPEnums::LUMP lump, const size_t max
+		BSPEnums::LUMP lump, size_t max
 	);
 
-	bool ParseLump(
-		const uint8_t* pData, const size_t size,
+	void ParseLump(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::Plane** pArray, size_t* pLength
 	);
 
 
-	bool ParseLump(
-		const uint8_t* pData, const size_t size,
+	void ParseLump(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::Edge** pArray, size_t* pLength
 	);
 
-	bool ParseLump(
-		const uint8_t* pData, const size_t size,
+	void ParseLump(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::Face** pArray, size_t* pLength
 	);
 
-	bool ParseLump(
-		const uint8_t* pData, const size_t size,
+	void ParseLump(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::TexInfo** pArray, size_t* pLength
 	);
 
-	bool ParseLump(
-		const uint8_t* pData, const size_t size,
+	void ParseLump(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::TexData** pArray, size_t* pLength
 	);
 
-	bool ParseLump(
-		const uint8_t* pData, const size_t size,
+	void ParseLump(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::Model** pArray, size_t* pLength
 	);
 
-	bool ParseLump(
-		const uint8_t* pData, const size_t size,
+	void ParseLump(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::DispInfo** pArray, size_t* pLength
 	);
 
-	bool ParseLump(
-		const uint8_t* pData, const size_t size,
+	void ParseLump(
+		const uint8_t* pData, size_t size,
 		const BSPStructs::Header* pHeader,
 		const BSPStructs::DispVert** pArray, size_t* pLength
 	);

--- a/FileFormat/Structs.h
+++ b/FileFormat/Structs.h
@@ -332,6 +332,26 @@ namespace BSPStructs {
 		uint16_t maxDXLevel;
 	};
 
+	struct StaticPropV7Multiplayer2013
+	{
+		Vector   origin;
+		QAngle   angles;
+		uint16_t propType;
+		uint16_t firstLeaf;
+		uint16_t leafCount;
+		uint8_t  solid;
+		int32_t  skin;
+		float    fadeMinDist;
+		float    fadeMaxDist;
+		Vector   lightingOrigin;
+		float    flForcedFadeScale;
+		uint16_t minDXLevel;
+		uint16_t maxDXLevel;
+		uint32_t flags;
+		uint8_t LightmapResX;
+		uint8_t lightmapResY;
+	};
+
 	struct StaticPropLeaf
 	{
 		uint16_t leaf;


### PR DESCRIPTION
# Changes

- Adds `errorReason` and `errorLump` properties to `BSPMap`
- Switched from status boolean approach to throwing parse and triangulation errors with detailed messages
- Catches errors in the constructor and sets the error reason and lump (where applicable)
- Adds a new `LUMP::NONE` enum value to indicate that the error did not occur within a lump
- Adds support for the v7* static prop lump version unique to the 2013 multiplayer SDK

# Impact

- Allows library users to better report issues with specific maps, and surface more granular errors to end users
- Implemented in such a way that there should be no breaking changes
- Adds support for parsing many more maps