### PR TITLE
251 - LZMA support

### DIFF
--- a/packages/bspparser/bsp.cpp
+++ b/packages/bspparser/bsp.cpp
@@ -5,12 +5,15 @@
 namespace BspParser {
   using namespace BspParser::Internal;
 
-  Bsp::Bsp(const std::span<std::byte const> data, std::optional<LZMADecompressCallback> lzmaDecompressCallback) : data(data), lzmaDecompressCallback(lzmaDecompressCallback) {
+  Bsp::Bsp(const std::span<std::byte const> data, std::optional<LZMADecompressCallback> lzmaDecompressCallback)
+    : data(data), lzmaDecompressCallback(lzmaDecompressCallback) {
     if (data.size_bytes() < sizeof(Structs::Header)) {
       throw Errors::OutOfBoundsAccess(
         Enums::Lump::None,
         std::format(
-          "Size of data ({}) is less than the size of the header type ({})", data.size_bytes(), sizeof(Structs::Header)
+          "Size of data ({}) is less than the size of the header type ({})",
+          data.size_bytes(),
+          sizeof(Structs::Header)
         )
       );
     }
@@ -103,7 +106,8 @@ namespace BspParser {
       throw Errors::InvalidBody(
         Enums::Lump::GameLump,
         std::format(
-          "Game lump header has length ({}) less than the single int32 needed for the count", lumpHeader.length
+          "Game lump header has length ({}) less than the single int32 needed for the count",
+          lumpHeader.length
         )
       );
     }
@@ -123,7 +127,8 @@ namespace BspParser {
     }
 
     return std::span(
-      reinterpret_cast<const Structs::GameLump*>(&data[lumpHeader.offset + sizeof(int32_t)]), numGameLumpHeaders
+      reinterpret_cast<const Structs::GameLump*>(&data[lumpHeader.offset + sizeof(int32_t)]),
+      numGameLumpHeaders
     );
   }
 
@@ -131,9 +136,10 @@ namespace BspParser {
     const auto& lumpHeader = header->lumps.at(static_cast<size_t>(Enums::Lump::PhysCollide));
     assertLumpHeaderValid(Enums::Lump::PhysCollide, lumpHeader);
 
-    const auto lumpData = isLumpCompressed(Enums::Lump::PhysCollide) ?
-                          decompressLump<std::byte>(Enums::Lump::PhysCollide, reinterpret_cast<const Structs::LzmaHeader*>(&data[lumpHeader.offset])) :
-                          data.subspan(lumpHeader.offset, lumpHeader.length);
+    const auto lumpSpan = data.subspan(lumpHeader.offset, lumpHeader.length);
+    const auto lumpData = isLumpCompressed(Enums::Lump::PhysCollide)
+      ? decompressLump(Enums::Lump::PhysCollide, lumpSpan)
+      : lumpSpan;
 
     const auto lumpLength = lumpData.size_bytes();
 
@@ -145,7 +151,8 @@ namespace BspParser {
 
       if (remainingBytes < sizeof(Structs::PhysModelHeader)) {
         throw Errors::InvalidBody(
-          Enums::Lump::PhysCollide, std::format("PhysCollide lump is not terminated with a negative model index")
+          Enums::Lump::PhysCollide,
+          std::format("PhysCollide lump is not terminated with a negative model index")
         );
       }
 
@@ -220,7 +227,13 @@ namespace BspParser {
     const auto surfaceEdgesForDisplacement = surfaceEdges.subspan(face.firstEdge, face.numEdges);
 
     return TriangulatedDisplacement(
-      displacementInfo, displacementVertices, edges, vertices, surfaceEdgesForDisplacement, textureInfo, textureData
+      displacementInfo,
+      displacementVertices,
+      edges,
+      vertices,
+      surfaceEdgesForDisplacement,
+      textureInfo,
+      textureData
     );
   }
 }

--- a/packages/bspparser/bsp.cpp
+++ b/packages/bspparser/bsp.cpp
@@ -183,7 +183,7 @@ namespace BspParser {
     return std::move(physicsModels);
   }
 
-  std::vector<Zip::ZipFileEntry> Bsp::parsePakfileLump() const {
+  std::vector<Zip::ZipFileEntry> Bsp::parsePakfileLump() {
     const auto& lumpHeader = header->lumps.at(static_cast<size_t>(Enums::Lump::PakFile));
     assertLumpHeaderValid(Enums::Lump::PakFile, lumpHeader);
 

--- a/packages/bspparser/bsp.cpp
+++ b/packages/bspparser/bsp.cpp
@@ -5,7 +5,7 @@
 namespace BspParser {
   using namespace BspParser::Internal;
 
-  Bsp::Bsp(const std::span<std::byte const> data, std::optional<LZMADecompressCallback> lzmaDecompressCallback)
+  Bsp::Bsp(const std::span<std::byte const> data, std::optional<LzmaDecompressCallback> lzmaDecompressCallback)
     : data(data), lzmaDecompressCallback(lzmaDecompressCallback) {
     if (data.size_bytes() < sizeof(Structs::Header)) {
       throw Errors::OutOfBoundsAccess(

--- a/packages/bspparser/bsp.hpp
+++ b/packages/bspparser/bsp.hpp
@@ -204,7 +204,7 @@ namespace BspParser {
       }
 
       const auto isGameLumpCompressed = lumpHeader.flags & Structs::GameLump::COMPRESSED_FLAG != 0;
-      const auto gameLumpSpan = std::span(&data[lumpHeader.offset], lumpHeader.length);
+      const auto gameLumpSpan = data.subspan(lumpHeader.offset, lumpHeader.length);
 
       const auto dictionaryData = SourceParsers::Internal::OffsetDataView(
         isGameLumpCompressed

--- a/packages/bspparser/bsp.hpp
+++ b/packages/bspparser/bsp.hpp
@@ -33,7 +33,7 @@ namespace BspParser {
   struct Bsp {
     explicit Bsp(
       std::span<const std::byte> data,
-      std::optional<LZMADecompressCallback> lzmaDecompressCallback = std::nullopt
+      std::optional<LzmaDecompressCallback> lzmaDecompressCallback = std::nullopt
     );
 
     std::span<const std::byte> data;
@@ -69,7 +69,7 @@ namespace BspParser {
     std::vector<Zip::ZipFileEntry> compressedPakfile;
 
     std::vector<std::vector<std::byte>> decompressedLumps;
-    std::optional<LZMADecompressCallback> lzmaDecompressCallback = std::nullopt;
+    std::optional<LzmaDecompressCallback> lzmaDecompressCallback = std::nullopt;
 
     // std::span<const Structs::DetailObjectDict> detailObjectDictionary;
     // std::span<const Structs::DetailObject> detailObjects;
@@ -108,7 +108,7 @@ namespace BspParser {
       );
 
       const auto callback = lzmaDecompressCallback.value();
-      const auto metadata = LZMAMetadata{
+      const auto metadata = LzmaMetadata{
         .uncompressedSize = header.uncompressedSize,
         .properties = {
           header.properties[0],

--- a/packages/bspparser/bsp.hpp
+++ b/packages/bspparser/bsp.hpp
@@ -12,6 +12,7 @@
 #include "phys-model.hpp"
 #include "displacements/triangulated-displacement.hpp"
 #include "enums/lump.hpp"
+#include "helpers/lzma-callback.hpp"
 #include "helpers/zip.hpp"
 #include "structs/common.hpp"
 #include "structs/detail-props.hpp"
@@ -24,18 +25,6 @@
 #include "structs/lzma-header.hpp"
 
 namespace BspParser {
-  struct LZMAMetadata {
-    uint32_t dictSize;
-    uint32_t uncompressedSize;
-    uint8_t properties[5];
-  };
-
-  /**
-   * Callback method for decompressing any LZMA lumps in the BSP. If not provided, parsing will fail if any LZMA lumps are encountered.
-   * This should return a vector of the uncompressed data after LZMA decompression.
-   */
-  using LZMADecompressCallback = std::function<std::vector<std::byte>(std::span<const std::byte> compressedData, LZMAMetadata metadata)>;
-
   /**
    * Lightweight abstraction over a BSP file, providing direct access to many of its lumps without any additional allocations.
    *
@@ -112,7 +101,6 @@ namespace BspParser {
       const auto compressedData = std::span<const std::byte>(compressedDataStart, header->compressedSize);
       const auto callback = lzmaDecompressCallback.value();
       const auto metadata = LZMAMetadata{
-        .dictSize = header->compressedSize,
         .uncompressedSize = header->uncompressedSize,
         .properties = { header->properties[0], header->properties[1], header->properties[2], header->properties[3], header->properties[4] }
       };
@@ -246,7 +234,7 @@ namespace BspParser {
       return props;
     }
 
-    [[nodiscard]] std::vector<Zip::ZipFileEntry> parsePakfileLump() const;
+    [[nodiscard]] std::vector<Zip::ZipFileEntry> parsePakfileLump();
 
     void assertLumpHeaderValid(Enums::Lump lump, const Structs::Lump& lumpHeader) const;
 

--- a/packages/bspparser/bsp.hpp
+++ b/packages/bspparser/bsp.hpp
@@ -122,10 +122,14 @@ namespace BspParser {
       decompressedLumps.push_back(callback(lumpData.subspan(sizeof(Structs::LzmaHeader)), metadata));
 
       const auto& decompressedData = decompressedLumps.back();
-      return std::span<const LumpType>(
-        reinterpret_cast<const LumpType*>(decompressedData.data()),
-        header.uncompressedSize / sizeof(LumpType)
+      const auto decompressedOffsetView = SourceParsers::Internal::OffsetDataView(decompressedData);
+      const auto items = decompressedOffsetView.parseStructArray<LumpType>(
+        0,
+        header.uncompressedSize / sizeof(LumpType),
+        "Decompressed data is less than the intended size"
       );
+
+      return items;
     }
 
     bool isLumpCompressed(Enums::Lump lump) const {

--- a/packages/bspparser/enums/zip.hpp
+++ b/packages/bspparser/enums/zip.hpp
@@ -3,17 +3,11 @@
 
 namespace BspParser::Enums {
   /**
-   * https://www.iana.org/assignments/media-types/application/zip
+   * https://sourcegraph.com/github.com/lua9520/source-engine-2018-hl2_src@3bf9df6b2785fa6d951086978a3e66f49427166a/-/blob/public/zip_utils.h?L26:3-26:24
    */
   enum class ZipCompressionMethod : uint16_t {
-    Uncompressed,
-    Shrunk,
-    CompressionFactor1,
-    CompressionFactor2,
-    CompressionFactor3,
-    CompressionFactor4,
-    Imploded,
-    ReservedForTokenisingCompressionAlgorithm, // ???
-    Deflated,
+    Unknown = -1,
+    None = 0,
+    LZMA = 14
   };
 }

--- a/packages/bspparser/errors.hpp
+++ b/packages/bspparser/errors.hpp
@@ -42,6 +42,7 @@ namespace BspParser::Errors {
   ERROR_FOR_REASON(InvalidChecksum);
   ERROR_FOR_REASON(UnsupportedVersion);
   ERROR_FOR_REASON(OutOfBoundsAccess);
+  ERROR_FOR_REASON(MissingDecompressCallback);
 }
 
 #undef ERROR_FOR_REASON

--- a/packages/bspparser/errors.hpp
+++ b/packages/bspparser/errors.hpp
@@ -17,6 +17,7 @@ namespace BspParser::Errors {
     InvalidChecksum,
     UnsupportedVersion,
     OutOfBoundsAccess,
+    MissingDecompressCallback,
   };
 
   class Error : public std::runtime_error {

--- a/packages/bspparser/helpers/lzma-callback.hpp
+++ b/packages/bspparser/helpers/lzma-callback.hpp
@@ -4,12 +4,16 @@
 #include <vector>
 #include <functional>
 #include <span>
+#include <array>
 
 namespace BspParser {
-  struct LZMAMetadata {
+  struct LzmaMetadata {
     uint32_t uncompressedSize;
-    uint8_t properties[5];
+    std::array<uint8_t, 5> properties;
   };
 
-  using LZMADecompressCallback = std::function<std::vector<std::byte>(std::span<const std::byte> compressedData, LZMAMetadata metadata)>;
+  using LzmaDecompressCallback = std::function<std::vector<std::byte>(
+    std::span<const std::byte> compressedData,
+    LzmaMetadata metadata
+  )>;
 }

--- a/packages/bspparser/helpers/lzma-callback.hpp
+++ b/packages/bspparser/helpers/lzma-callback.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <functional>
+#include <span>
+
+namespace BspParser {
+  struct LZMAMetadata {
+    uint32_t uncompressedSize;
+    uint8_t properties[5];
+  };
+
+  using LZMADecompressCallback = std::function<std::vector<std::byte>(std::span<const std::byte> compressedData, LZMAMetadata metadata)>;
+}

--- a/packages/bspparser/helpers/zip.hpp
+++ b/packages/bspparser/helpers/zip.hpp
@@ -1,15 +1,26 @@
 #pragma once
 
+#include <optional>
+
+#include "lzma-callback.hpp"
 #include "../structs/zip.hpp"
 #include <span>
 #include <string_view>
 #include <vector>
 
 namespace BspParser::Zip {
+  struct ZipFileLZMA {
+    uint8_t majorVersion;
+    uint8_t minorVersion;
+    uint32_t uncompressedSize;
+    uint8_t properties[5];
+  };
+
   struct ZipFileEntry {
     Structs::Zip::FileHeader header;
     std::string_view fileName;
     std::span<const std::byte> data;
+    std::optional<ZipFileLZMA> lzmaMetadata;
   };
 
   std::vector<ZipFileEntry> readZipFileEntries(std::span<const std::byte> zipData);

--- a/packages/bspparser/helpers/zip.hpp
+++ b/packages/bspparser/helpers/zip.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <optional>
 
 #include "lzma-callback.hpp"
@@ -9,11 +10,11 @@
 #include <vector>
 
 namespace BspParser::Zip {
-  struct ZipFileLZMA {
+  struct ZipFileLzmaMetadata {
     uint8_t majorVersion;
     uint8_t minorVersion;
     uint32_t uncompressedSize;
-    uint8_t properties[5];
+    std::array<uint8_t, 5> properties;
     uint8_t compressionHeaderSize = sizeof(Structs::Zip::CompressionPayload);
   };
 
@@ -21,7 +22,7 @@ namespace BspParser::Zip {
     Structs::Zip::FileHeader header;
     std::string_view fileName;
     std::span<const std::byte> data;
-    std::optional<ZipFileLZMA> lzmaMetadata;
+    std::optional<ZipFileLzmaMetadata> lzmaMetadata;
   };
 
   std::vector<ZipFileEntry> readZipFileEntries(std::span<const std::byte> zipData);

--- a/packages/bspparser/helpers/zip.hpp
+++ b/packages/bspparser/helpers/zip.hpp
@@ -14,6 +14,7 @@ namespace BspParser::Zip {
     uint8_t minorVersion;
     uint32_t uncompressedSize;
     uint8_t properties[5];
+    uint8_t compressionHeaderSize = sizeof(Structs::Zip::CompressionPayload);
   };
 
   struct ZipFileEntry {

--- a/packages/bspparser/structs/headers.hpp
+++ b/packages/bspparser/structs/headers.hpp
@@ -53,6 +53,8 @@ namespace BspParser::Structs {
   };
 
   struct GameLump {
+    static constexpr auto COMPRESSED_FLAG = 0x0001;
+
     Enums::GameLumpID id;
     uint16_t flags;
     uint16_t version;

--- a/packages/bspparser/structs/lzma-header.hpp
+++ b/packages/bspparser/structs/lzma-header.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace BspParser::Structs {
+  struct LzmaHeader {
+    static constexpr uint32_t LZMA_ID = 'A' << 24 | 'M' << 16 | 'Z' << 8 | 'L';
+
+    uint32_t id;
+    uint32_t uncompressedSize;
+    uint32_t compressedSize;
+    uint8_t properties[5];
+  };
+}

--- a/packages/bspparser/structs/lzma-header.hpp
+++ b/packages/bspparser/structs/lzma-header.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 namespace BspParser::Structs {
+#pragma pack(push, 1)
   struct LzmaHeader {
     static constexpr uint32_t LZMA_ID = 'A' << 24 | 'M' << 16 | 'Z' << 8 | 'L';
 
@@ -11,4 +12,5 @@ namespace BspParser::Structs {
     uint32_t compressedSize;
     uint8_t properties[5];
   };
+#pragma pack(pop)
 }

--- a/packages/bspparser/structs/zip.hpp
+++ b/packages/bspparser/structs/zip.hpp
@@ -60,5 +60,11 @@ namespace BspParser::Structs::Zip {
     uint16_t extraFieldLength;
   };
 
+  struct CompressionPayload {
+    uint8_t lzmaSdkMajorVersion;
+    uint8_t lzmaSdkMinorVersion;
+    uint16_t propertiesSize; // In practice, this should always be 5. If it's not, nothing will work anyways
+    uint8_t properties[5];
+  };
 #pragma pack(pop)
 }


### PR DESCRIPTION
Resolves #12 
# Changes

- Adds a LZMA decompression callback to `BspParser::Bsp` so users can specify a function to decompress any lumps that are compressed with LZMA. This makes maps in TF2 work, and GMod workshop maps using Hammer++.
- Adds metadata to zip file entries to allow the user to work out the proper decompression required to read a compressed file in the Pakfile lump

Anyways, something to note is that it seems like Source Engine's LZMA encoder (7z sdk) is somehow different in the LZMA1 encoding part of things because I *could* not get `liblzma` to play nice with the data even though they both supposedly support LZMA1.

Maybe I need to add something about this to the README? Seems like a very pertinent detail that the users are going to need to know to support LZMA maps.