### PR TITLE
NONE - Fix some regressions that make Linux compiles fail

### DIFF
--- a/packages/bspparser/bsp.hpp
+++ b/packages/bspparser/bsp.hpp
@@ -207,7 +207,7 @@ namespace BspParser {
         );
       }
 
-      const auto isGameLumpCompressed = lumpHeader.flags & Structs::GameLump::COMPRESSED_FLAG != 0;
+      const auto isGameLumpCompressed = (lumpHeader.flags & Structs::GameLump::COMPRESSED_FLAG) != 0;
       const auto gameLumpSpan = data.subspan(lumpHeader.offset, lumpHeader.length);
 
       const auto dictionaryData = SourceParsers::Internal::OffsetDataView(

--- a/packages/bspparser/enums/zip.hpp
+++ b/packages/bspparser/enums/zip.hpp
@@ -5,9 +5,7 @@ namespace BspParser::Enums {
   /**
    * https://sourcegraph.com/github.com/lua9520/source-engine-2018-hl2_src@3bf9df6b2785fa6d951086978a3e66f49427166a/-/blob/public/zip_utils.h?L26:3-26:24
    */
-  enum class ZipCompressionMethod : uint16_t {
-    Unknown = -1,
-    None = 0,
-    LZMA = 14
+  enum class ZipCompressionMethod : int16_t {
+    Unknown = -1, None = 0, LZMA = 14
   };
 }


### PR DESCRIPTION
## Changes

- Switch to `int16_t` enum class for the compression method enum
- Add parentheses around the bitwise op to check if a game lump is compressed